### PR TITLE
Always copy rust libs

### DIFF
--- a/RustPlayground/RustPlayground.xcodeproj/project.pbxproj
+++ b/RustPlayground/RustPlayground.xcodeproj/project.pbxproj
@@ -61,7 +61,7 @@
 /* Begin PBXCopyFilesBuildPhase section */
 		603B0594227204B300FBD7FC /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
+			buildActionMask = 12;
 			dstPath = "";
 			dstSubfolderSpec = 16;
 			files = (
@@ -71,7 +71,7 @@
 		};
 		603B05972272063700FBD7FC /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
+			buildActionMask = 12;
 			dstPath = "";
 			dstSubfolderSpec = 16;
 			files = (
@@ -401,7 +401,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# When building from Xcode we want to ensure that `cargo` is in PATH.\n# as a convenience, add the default cargo install location\nexport PATH=\"$PATH:${HOME}/.cargo/bin\"\n\nset -e\n\nif [[ $CONFIGURATION = \"Debug\" ]]; then\nRUST_CONFIGURATION=\"debug\"\nRUST_CONFIGURATION_FLAG=\"\"\nelse\nRUST_CONFIGURATION=\"release\"\nRUST_CONFIGURATION_FLAG=\"--release\"\nfi\n\nCRATE_ROOT=\"${SRCROOT}/../playground-utils-ffi\"\nOUTDIR=\"$CRATE_ROOT/target/\"\nPRODUCT_NAME=\"libplayground.a\"\n\ncd \"${CRATE_ROOT}\"\n\necho \"building ${CRATE_ROOT}, conf ${RUST_CONFIGURATION}, action ${ACTION}\"\n\nif [[ ${ACTION:-build} = \"build\" ]]; then\ncargo build $RUST_CONFIGURATION_FLAG\necho \"cargo built, copying to ${BUILT_PRODUCTS_DIR}\"\n# install is a separate action; we copy to a set location\n# so we can copy the file in the copy files stage\nelif [[ $ACTION = \"install\" ]]; then\ncargo build $RUST_CONFIGURATION_FLAG\ncp \"${OUTDIR}/${RUST_CONFIGURATION}/${PRODUCT_NAME}\" \"${OUTDIR}/${PRODUCT_NAME}\"\nelif [[ $ACTION = \"clean\" ]]; then\necho \"cleaning\"\ncargo clean\nfi\n\nset +e\n";
+			shellScript = "# When building from Xcode we want to ensure that `cargo` is in PATH.\n# as a convenience, add the default cargo install location\nexport PATH=\"$PATH:${HOME}/.cargo/bin\"\n\nset -e\n\nif [[ $CONFIGURATION = \"Debug\" ]]; then\nRUST_CONFIGURATION=\"debug\"\nRUST_CONFIGURATION_FLAG=\"\"\nelse\nRUST_CONFIGURATION=\"release\"\nRUST_CONFIGURATION_FLAG=\"--release\"\nfi\n\nCRATE_ROOT=\"${SRCROOT}/../playground-utils-ffi\"\nOUTDIR=\"$CRATE_ROOT/target/\"\nPRODUCT_NAME=\"libplayground.a\"\n\ncd \"${CRATE_ROOT}\"\n\necho \"building ${CRATE_ROOT}, conf ${RUST_CONFIGURATION}, action ${ACTION}\"\n\nif [[ ${ACTION:-build} = \"build\" || $ACTION = \"install\" ]]; then\ncargo build $RUST_CONFIGURATION_FLAG\ncp \"${OUTDIR}/${RUST_CONFIGURATION}/${PRODUCT_NAME}\" \"${OUTDIR}/${PRODUCT_NAME}\"\nfi\n\nset +e\n";
 		};
 		609A226322404D0D00A3F007 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -418,7 +418,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# When building from Xcode we want to ensure that `cargo` is in PATH.\n# as a convenience, add the default cargo install location\nexport PATH=\"$PATH:${HOME}/.cargo/bin\"\n\nset -e\n\nif [[ $CONFIGURATION = \"Debug\" ]]; then\n    RUST_CONFIGURATION=\"debug\"\n    RUST_CONFIGURATION_FLAG=\"\"\nelse\n    RUST_CONFIGURATION=\"release\"\n    RUST_CONFIGURATION_FLAG=\"--release\"\nfi\n\ncd \"${SRCROOT}/../xi-ffi\"\n\necho \"rust config ${RUST_CONFIGURATION}, action ${ACTION}\"\n\nif [[ ${ACTION:-build} = \"build\" ]]; then\n    cargo build $RUST_CONFIGURATION_FLAG\n#echo \"cargo built, copying to ${BUILT_PRODUCTS_DIR}\"\n    cp \"${SRCROOT}/../xi-ffi/target/${RUST_CONFIGURATION}/libximodal.a\" \"${SRCROOT}/../xi-ffi/target/libximodal.a\"\nelif [[ $ACTION = \"clean\" ]]; then\n    echo \"cleaing\"\n    cargo clean\nfi\n\nset +e\n\n# When building from Xcode we want to ensure that `cargo` is in PATH.\n# as a convenience, add the default cargo install location\nexport PATH=\"$PATH:${HOME}/.cargo/bin\"\n\nset -e\n\nif [[ $CONFIGURATION = \"Debug\" ]]; then\nRUST_CONFIGURATION=\"debug\"\nRUST_CONFIGURATION_FLAG=\"\"\nelse\nRUST_CONFIGURATION=\"release\"\nRUST_CONFIGURATION_FLAG=\"--release\"\nfi\n\nCRATE_ROOT=\"${SRCROOT}/../xi-ffi\"\nOUTDIR=\"$CRATE_ROOT/target/\"\nPRODUCT_NAME=\"libximodal.a\"\n\ncd \"${CRATE_ROOT}\"\n\necho \"building ${CRATE_ROOT}, conf ${RUST_CONFIGURATION}, action ${ACTION}\"\n\nif [[ ${ACTION:-build} = \"build\" ]]; then\ncargo build $RUST_CONFIGURATION_FLAG\nelif [[ $ACTION = \"install\" ]]; then\n# install is a separate action; we copy to a set location\n# so we can copy the file in the copy files stage\ncargo build $RUST_CONFIGURATION_FLAG\ncp \"${OUTDIR}/${RUST_CONFIGURATION}/${PRODUCT_NAME}\" \"${OUTDIR}/${PRODUCT_NAME}\"\nelif [[ $ACTION = \"clean\" ]]; then\necho \"cleaning\"\ncargo clean\nelse\necho \"unknown action $ACTION\"\nfi\n\nset +e\n";
+			shellScript = "# When building from Xcode we want to ensure that `cargo` is in PATH.\n# as a convenience, add the default cargo install location\nexport PATH=\"$PATH:${HOME}/.cargo/bin\"\n\nset -e\n\nif [[ $CONFIGURATION = \"Debug\" ]]; then\nRUST_CONFIGURATION=\"debug\"\nRUST_CONFIGURATION_FLAG=\"\"\nelse\nRUST_CONFIGURATION=\"release\"\nRUST_CONFIGURATION_FLAG=\"--release\"\nfi\n\nCRATE_ROOT=\"${SRCROOT}/../xi-ffi\"\nOUTDIR=\"$CRATE_ROOT/target/\"\nPRODUCT_NAME=\"libximodal.a\"\n\ncd \"${CRATE_ROOT}\"\n\necho \"building ${CRATE_ROOT}, conf ${RUST_CONFIGURATION}, action ${ACTION}\"\n\nif [[ ${ACTION:-build} = \"build\" || $ACTION = \"install\" ]]; then\ncargo build $RUST_CONFIGURATION_FLAG\ncp \"${OUTDIR}/${RUST_CONFIGURATION}/${PRODUCT_NAME}\" \"${OUTDIR}/${PRODUCT_NAME}\"\nfi\n\nset +e\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
@jspencer, could you check that this resolves your issue?

This ensures we always copy the last compiled version of the static
libs into the base target/ directory for that lib, whic his where
we look for them when copying into the bundle.

- closes #6