### PR TITLE
Migrate playground-utils to ffi_support

### DIFF
--- a/playground-utils-ffi/Cargo.toml
+++ b/playground-utils-ffi/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Colin Rofls <colin@cmyr.net>"]
 edition = "2018"
 
 [dependencies]
+ffi-support = "0.3.4"
 serde_json = "1.0"
 
 [dependencies.playground-utils]

--- a/playground-utils-ffi/playground.h
+++ b/playground-utils-ffi/playground.h
@@ -4,8 +4,13 @@
 typedef const char* json;
 typedef void (*stderr_callback)(const char*);
 
-extern json playgroundGetToolchains();
-extern json playgroundExecuteTask(const char* path, json, stderr_callback);
+typedef struct _ExternError {
+    int32_t code;
+    char *message; // note: nullable
+} ExternError;
+
+extern json playgroundGetToolchains(ExternError* error);
+extern json playgroundExecuteTask(const char* path, json, stderr_callback, ExternError* error);
 
 extern void playgroundStringFree(json);
 

--- a/playground-utils-ffi/src/lib.rs
+++ b/playground-utils-ffi/src/lib.rs
@@ -1,23 +1,17 @@
-#[macro_use]
-extern crate serde_json;
-
 use libc::c_char;
 use std::ffi::{CStr, CString, OsStr};
 use std::os::unix::ffi::OsStrExt;
 use std::path::Path;
 
-use playground_utils::{do_compile_task, list_toolchains, Error, Task};
+use ffi_support::{call_with_result, ExternError};
+use playground_utils::{do_compile_task, list_toolchains, Task};
 
 #[no_mangle]
-pub extern "C" fn playgroundGetToolchains() -> *const c_char {
-    let response = match list_toolchains() {
-        Ok(toolchains) => json!({ "result": toolchains }),
-        Err(e) => to_json_error(e),
-    };
-
-    let response_str = serde_json::to_string(&response).unwrap();
-    let cstring = CString::new(response_str).expect("nul byte in response json");
-    cstring.into_raw()
+pub extern "C" fn playgroundGetToolchains(err: &mut ExternError) -> *const c_char {
+    call_with_result(err, || {
+        list_toolchains()
+            .map(|r| serde_json::to_string(&r).unwrap())
+    })
 }
 
 #[no_mangle]
@@ -25,25 +19,22 @@ pub extern "C" fn playgroundExecuteTask(
     path: *const c_char,
     cmd_json: *const c_char,
     std_err_callback: extern "C" fn(*const c_char),
+    err: &mut ExternError,
 ) -> *const c_char {
-    eprintln!("playground execute task");
-    let path = unsafe { CStr::from_ptr(path) };
-    let json = unsafe { CStr::from_ptr(cmd_json) };
-    let path = Path::new(OsStr::from_bytes(path.to_bytes()));
-    let json = json.to_str().expect("json must be valid utf8");
-    let task: Task = serde_json::from_str(json).expect("malformed task json");
-    let response = match do_compile_task(path, task, |stderr| {
-        let cstring =
-            CString::new(stderr).unwrap_or_else(|_| CString::new("null byte in stderr").unwrap());
-        std_err_callback(cstring.as_ptr());
-    }) {
-        Ok(result) => json!({ "result": result }),
-        Err(e) => to_json_error(e),
-    };
-
-    let response_str = serde_json::to_string(&response).unwrap();
-    let cstring = CString::new(response_str).expect("nul byte in response json");
-    cstring.into_raw()
+    call_with_result(err, || {
+        eprintln!("playground execute task");
+        let path = unsafe { CStr::from_ptr(path) };
+        let json = unsafe { CStr::from_ptr(cmd_json) };
+        let path = Path::new(OsStr::from_bytes(path.to_bytes()));
+        let json = json.to_str().expect("json must be valid utf8");
+        let task: Task = serde_json::from_str(json).expect("malformed task json");
+        do_compile_task(path, task, |stderr| {
+            let cstring = CString::new(stderr)
+                .unwrap_or_else(|_| CString::new("null byte in stderr").unwrap());
+            std_err_callback(cstring.as_ptr());
+        })
+        .map(|r| serde_json::to_string(&r).unwrap())
+    })
 }
 
 #[no_mangle]
@@ -55,13 +46,4 @@ pub extern "C" fn playgroundStringFree(ptr: *mut c_char) {
     unsafe {
         CString::from_raw(ptr);
     }
-}
-
-fn to_json_error(e: Error) -> serde_json::Value {
-    json!({
-        "error": {
-            "message": e.to_string(),
-            "code": e.error_code(),
-        }
-    })
 }

--- a/playground-utils/Cargo.toml
+++ b/playground-utils/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "playground-utils"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Colin Rofls <colin@cmyr.net>"]
 edition = "2018"
 
 [dependencies]
 dirs = "1.0"
+ffi-support = "0.3.4"
 serde = "1.0"
 serde_derive = "1.0"
 semver = "0.9"

--- a/playground-utils/src/error.rs
+++ b/playground-utils/src/error.rs
@@ -3,6 +3,8 @@ use std::io;
 use std::path::PathBuf;
 use std::process::Output;
 
+use ffi_support::{ExternError, ErrorCode};
+
 #[derive(Debug)]
 pub enum Error {
     ToolchainParseError(String),
@@ -36,7 +38,7 @@ impl Error {
     /// An error code included in the json if this is sent to core.
     /// This is not systematic. We just want to be able to easily identify
     /// certain cases, such as when Rustup is not installed.
-    pub fn error_code(&self) -> u32 {
+    pub fn error_code(&self) -> i32 {
         use Error::*;
         match self {
             BadExit(_) => 1,
@@ -71,3 +73,10 @@ impl fmt::Display for Error {
 }
 
 impl std::error::Error for Error {}
+
+impl From<Error> for ExternError {
+    fn from(e: Error) -> ExternError {
+        let code = ErrorCode::new(e.error_code());
+        ExternError::new_error(code, e.to_string())
+    }
+}


### PR DESCRIPTION
This is a test run of using the patterns encouraged by mozilla's
ffi-support crate (https://docs.rs/ffi-support).

I wasn't totally sure how this would go, but it was relatively painless
and I'm encouraged by the code.

While I was in here I also did some general cleanup on the swift side

progress on #5 (still need to rework the other library that handles xi stuff)